### PR TITLE
Split settings by environment

### DIFF
--- a/showCrime/manage.py
+++ b/showCrime/manage.py
@@ -3,7 +3,7 @@ import os
 import sys
 
 if __name__ == "__main__":
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "showCrime.settings")
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "showCrime.settings.development")
     try:
         from django.core.management import execute_from_command_line
     except ImportError:

--- a/showCrime/showCrime/settings/base.py
+++ b/showCrime/showCrime/settings/base.py
@@ -240,12 +240,6 @@ CRON_CLASSES = [
 	'django_cron.cron.FailedRunsNotificationCronJob',
 ]
 
-# Email config, ala https://docs.webfaction.com/software/django/getting-started.html?highlight=django%2520email#configuring-django-to-send-email-messages
-ADMIN = ((env('ADMIN_USER'),env('ADMIN_EMAIL')))
-EMAIL_HOST = env('EMAIL_HOST')
-EMAIL_HOST_USER = env('EMAIL_HOST_USER')
-EMAIL_HOST_PASSWORD  = env('EMAIL_PW')
-SERVER_EMAIL = env('SERVER_EMAIL')
 SITE_URL = env('SITE_URL')
 
 DEBUG_TOOLBAR_PATCH_SETTINGS = False
@@ -255,25 +249,3 @@ DEBUG_TOOLBAR_PATCH_SETTINGS = False
 
 LOG_FILE_PATH = os.path.join(root, "logs") 
 PLOT_PATH = os.path.join(root, "plots") 
-
-###################
-# echo settings
-
-import django
-print('settings: django version',django.__version__)
-print('settings: DEBUG',DEBUG)
-
-import socket
-HostName = socket.gethostname()
-print('settings: HostName', HostName)
-print('settings: root', root)
-print('settings: STATIC_URL', STATIC_URL)
-print('settings: SITE_URL', SITE_URL)
-print('settings: STATICFILES_DIRS', STATICFILES_DIRS)
-print('settings: MEDIA_ROOT', MEDIA_ROOT)
-print('settings: LOG_FILE_PATH', LOG_FILE_PATH)
-print('settings: PLOT_PATH', PLOT_PATH)
-print('settings: database hosted at %s:%s' % (DATABASES['default']["HOST"],DATABASES['default']["NAME"]))
-print('settings: DEBUG',DEBUG)
-
-

--- a/showCrime/showCrime/settings/development.py
+++ b/showCrime/showCrime/settings/development.py
@@ -1,0 +1,21 @@
+from .base import *
+
+###################
+# echo settings
+
+import django
+print('settings: django version',django.__version__)
+print('settings: DEBUG',DEBUG)
+
+import socket
+HostName = socket.gethostname()
+print('settings: HostName', HostName)
+print('settings: root', root)
+print('settings: STATIC_URL', STATIC_URL)
+print('settings: SITE_URL', SITE_URL)
+print('settings: STATICFILES_DIRS', STATICFILES_DIRS)
+print('settings: MEDIA_ROOT', MEDIA_ROOT)
+print('settings: LOG_FILE_PATH', LOG_FILE_PATH)
+print('settings: PLOT_PATH', PLOT_PATH)
+print('settings: database hosted at %s:%s' % (DATABASES['default']["HOST"],DATABASES['default']["NAME"]))
+print('settings: DEBUG',DEBUG)

--- a/showCrime/showCrime/settings/production.py
+++ b/showCrime/showCrime/settings/production.py
@@ -1,0 +1,8 @@
+from .base import *
+
+# Email config, ala https://docs.webfaction.com/software/django/getting-started.html?highlight=django%2520email#configuring-django-to-send-email-messages
+ADMIN = ((env('ADMIN_USER'),env('ADMIN_EMAIL')))
+EMAIL_HOST = env('EMAIL_HOST')
+EMAIL_HOST_USER = env('EMAIL_HOST_USER')
+EMAIL_HOST_PASSWORD  = env('EMAIL_PW')
+SERVER_EMAIL = env('SERVER_EMAIL')


### PR DESCRIPTION
Noticed a few "required" settings like ADMIN and email settings that are only important for production. I prefer to keep settings declarative and avoid conditional logic which can hide errors. People don't usually write tests for their configurations, so it's best to keep it simple and declarative.

By default, the `development.py` settings are used. In production we'll set `DJANGO_SETTINGS_MODULE=showChime.settings.production` to use the production settings.