### PR TITLE
Add code owners to review PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# The review team must approve review all PRs
+* @openoakland/oakcrime-reviewers

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,12 @@ solved it. Please make sure that the code passes our code style (via `make
 lint`) and you include automated unit tests for your changes.
 
 
+### Reviewing pull requests
+
+All pull requests must be reviewed by the @openoakland/oakcrime-reviewers team
+before they can be merged.
+
+
 ## Continuous integration
 
 OakCrime practices continuous integration. Every pull request is tested by our


### PR DESCRIPTION
At OpenOakland tonight, @rbelew suggested that he take ownership over merging PRs. The team supports this decision. This PR adds an @openoakland/oakcrime-reviewers team as a code owner. Then we'll make PR reviews require a review from the code owner.

_P.S. I've never used this feature, so :crossed_fingers:_