### PR TITLE
add onClick link from maps to incident reports

### DIFF
--- a/showCrime/dailyIncid/templates/dailyIncid/ToBeImplemented.html
+++ b/showCrime/dailyIncid/templates/dailyIncid/ToBeImplemented.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+
+{% load static %}
+
+{% block title %} To Be Implemented! {% endblock %}
+
+{% block content %}
+<h1 align=center>To Be Implemented!</h1>
+<p>OpenOakland has this feature on its <a href="https://github.com/openoakland/OakCrime/issues"> repo Issues list</a>; check back.</p>
+{% endblock %}

--- a/showCrime/dailyIncid/templates/dailyIncid/heatmap.html
+++ b/showCrime/dailyIncid/templates/dailyIncid/heatmap.html
@@ -567,7 +567,9 @@
 			
 
 			map.on('click', 'incidMarker', function(e) {
-				var lbl = `<b>Incid#:</b> ${e.features[0].properties.opd_rd} ${e.features[0].properties.cdateTime}  ${e.features[0].properties.crimeCat}`
+
+		    var url = `/dailyIncid/incidRpt/${e.features[0].properties.opd_rd}`;
+			var lbl = `<a href="${url}"><b>Incid#: ${e.features[0].properties.opd_rd}</b></a> ${e.features[0].properties.cdateTime}  ${e.features[0].properties.crimeCat}`
 				
 			  new mapboxgl.Popup()
 			  	// mapzen version

--- a/showCrime/dailyIncid/templates/dailyIncid/incidRpt.html
+++ b/showCrime/dailyIncid/templates/dailyIncid/incidRpt.html
@@ -64,13 +64,18 @@
 		<dt>Crime category</dt><dd>{{incid.crimeCat}}</dd>
 	</dl>
 
-    <form id="downloadForm" action="/dailyIncid/need2login/">
+	<form id="downloadForm" action="/dailyIncid/ToBeImplemented">
 
 		<p align=center>Do you have 
 			<button type="submit" style="color:blue">information to share</button>
-			about this incident you wish to pass along to OPD?
+			about this incident you wish to <b>pass along to OPD?</b>
 		  </p>
-    </form>
+
+		<p align=center>Do you have 
+			<button type="submit" style="color:blue">information to share</button>
+			about this incident you wish to <b>share with Oakland citizens?</b>
+		  </p>
+	</form>
 
 	{% if incid.xlng != None %}
 

--- a/showCrime/dailyIncid/urls.py
+++ b/showCrime/dailyIncid/urls.py
@@ -30,6 +30,9 @@ urlpatterns = [
     url(r'^interface/$', TemplateView.as_view(template_name="dailyIncid/interface.html")),
     url(r'^faq/$', TemplateView.as_view(template_name="dailyIncid/faq.html")),
 
+	url(r'^ToBeImplemented/$', TemplateView.as_view(template_name="dailyIncid/ToBeImplemented.html")),
+
+
     url(r'heatmap/$', views.heatmap, name='heatmap'),
     url(r'heatmap/(?P<mapType>.+)/$', views.heatmap, name='heatmapTyped'),
 


### PR DESCRIPTION
Rather than just have the pop-info presented when an incident's dot on a map is clicked, make the incident# a hotlink to an incident report.
This responds to issue #33.