### PR TITLE
Update harvestPatrolLog variables to match EMR variables

### DIFF
--- a/showCrime/dailyIncid/management/commands/harvestPatrolLog.py
+++ b/showCrime/dailyIncid/management/commands/harvestPatrolLog.py
@@ -46,16 +46,13 @@ logger = logging.getLogger(__name__)
 
 # Credentials
 # env = environ.Env(DEBUG=(bool, False), ) # in settings
-GoogleMapAPIKey = env('GoogleMapAPIKey')
-BoxEnterpriseID = env('BoxEnterpriseID')
-BoxHarvestBotUserID = env('BoxHarvestBotUserID')
-BoxHarvestBotEmail= env('BoxHarvestBotEmail')
-BoxDevpToken = env('BoxDevpToken')
-BoxClientID = env('BoxClientID')
-BoxClientSecret = env('BoxClientSecret')
-BoxPublicKeyID = env('BoxPublicKeyID')
-BoxRSAFile = env('BoxRSAFile')
-BoxPassPhrase = env('BoxPassPhrase')
+GoogleMapAPIKey = env('GOOGLE_MAPS_API_KEI')
+BoxEnterpriseID = env('BOX_ENTERPRISE_ID')
+BoxClientID = env('BOX_CLIENT_ID')
+BoxClientSecret = env('BOX_CLIENT_SECRET')
+BoxPublicKeyID = env('BOX_PUBLIC_KEY_ID')
+BoxRSAKey = env('BOX_RSA_KEY')
+BoxPassPhrase = env('BOX_PASS_PHRASE')
 
 # Constants
 HarvestRootDir = MEDIA_ROOT + '/PLHarvest/'
@@ -120,7 +117,7 @@ def connectJWTAuth():
 		client_secret=BoxClientSecret,
 		enterprise_id=BoxEnterpriseID,
 		jwt_key_id=BoxPublicKeyID,
-		rsa_private_key_file_sys_path=BoxRSAFile,
+		rsa_private_key_data=BoxRSAKey,
 		rsa_private_key_passphrase=BoxPassPhrase,
 		store_tokens=store_tokens)
 	


### PR DESCRIPTION
They are all specified in all-caps by convention. Additionally, it
appeared that BoxHarvestBotEmail, BoxHarvestBotUserID, BoxDevpToken were
unused within the codebase, so I have removed them.

Also, it appears that the boxsdk library is able to receive the RSA key
as a string, which would streamline the process (in comparison to having
to write it out to a file). Let's try this and see if it works.